### PR TITLE
Disable default NTP suggestions

### DIFF
--- a/0008-restore-classic-ntp.patch
+++ b/0008-restore-classic-ntp.patch
@@ -19,3 +19,25 @@
    }
  
    GURL url;
+--- a/components/ntp_snippets/features.cc
++++ b/components/ntp_snippets/features.cc
+@@ -38,16 +38,16 @@ const base::Feature* const kAllFeatures[] = {
+     nullptr};
+ 
+ const base::Feature kArticleSuggestionsFeature{
+-    "NTPArticleSuggestions", base::FEATURE_ENABLED_BY_DEFAULT};
++    "NTPArticleSuggestions", base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+ const base::Feature kBookmarkSuggestionsFeature{
+-    "NTPBookmarkSuggestions", base::FEATURE_ENABLED_BY_DEFAULT};
++    "NTPBookmarkSuggestions", base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+ const base::Feature kRecentOfflineTabSuggestionsFeature{
+     "NTPOfflinePageSuggestions", base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+ const base::Feature kIncreasedVisibility{"NTPSnippetsIncreasedVisibility",
+-                                         base::FEATURE_ENABLED_BY_DEFAULT};
++                                         base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+ const base::Feature kPhysicalWebPageSuggestionsFeature{
+     "NTPPhysicalWebPageSuggestions", base::FEATURE_DISABLED_BY_DEFAULT};


### PR DESCRIPTION
I have applied the `0008-restore-classic-ntp.patch` but I still see it's trying to contact some NTP suggestions service, or at least it shows the loading animation for it.

My goal is to completely disable the "suggestions box" and related "learn more" link.

**NOTE**: I am building this change now, so I might know only later today if it works as expected, but I will update this PR accordingly

# Note about bromite
On a related topic, please note that I am cherry-picking some of the Ungoogled Chromium patches and Inox patchset (I didn't know Inox-patchset was still alive! glad to discover so) for [bromite](https://github.com/bromite/bromite), which has a slightly different target (general public, Android). I am doing so under the GPLv3 license that was in Ungoogled-Chromium.

My main work will be on the adblock features initially implemented by nochromo, so I guess I can consider ungoogled-chromium/inox-patchset as my upstream (nice idea to merge them btw) and we can share some patches. For example [this is the patch I am submitting in this PR](https://github.com/bromite/bromite/blob/master/patches/privacy/disable-ntp-remote-suggestions.patch).