### PR TITLE
Proposing search results click-tracking removal patch

### DIFF
--- a/remove-google-click-tracking.patch
+++ b/remove-google-click-tracking.patch
@@ -1,0 +1,57 @@
+commit 8d0b67d87462d537af6f7eb0cf445a2f66d5dd5c
+Author: csagan5 <32685696+csagan5@users.noreply.github.com>
+Date:   Sun Oct 15 18:01:18 2017 +0200
+
+    Remove click tracking from google search results
+
+diff --git a/third_party/WebKit/Source/core/dom/ContainerNode.cpp b/third_party/WebKit/Source/core/dom/ContainerNode.cpp
+index 1bada98..fb15e01 100644
+--- a/third_party/WebKit/Source/core/dom/ContainerNode.cpp
++++ b/third_party/WebKit/Source/core/dom/ContainerNode.cpp
+@@ -58,6 +58,8 @@
+ #include "platform/bindings/RuntimeCallStats.h"
+ #include "platform/bindings/V8PerIsolateData.h"
+ 
++#include "base/logging.h"
++
+ namespace blink {
+ 
+ using namespace HTMLNames;
+@@ -1391,6 +1393,26 @@ StaticElementList* ContainerNode::QuerySelectorAll(
+   return QuerySelectorAll(selectors, ASSERT_NO_EXCEPTION);
+ }
+ 
++// this logic here will cleanup click tracking from hyperlink nodes on search results
++static void applyInsertCustomization(Document *document, Node *c) {
++  if (c->getNodeType() != Node::kElementNode)
++	return;
++  Element *element = ToElement(c);
++
++  // filter out non-hyperlink nodes
++  if (element->tagName() != "A")
++	return;
++
++  // determine whether this is a Google search results page
++  WTF::String domain = document->GetSecurityOrigin()->Domain();
++  size_t pos = domain.Find(".google.");
++  if ((pos != WTF::kNotFound) && (domain.length() - pos - 8 < 4)) {
++    //LOG(INFO) << "sanitizing Google search results hyperlink, href: " << element->getAttribute("href") << " onmousedown: " << element->getAttribute("onmousedown");
++    // remove attribute
++    element->removeAttribute("onmousedown");
++  }
++}
++
+ static void DispatchChildInsertionEvents(Node& child) {
+   if (child.IsInShadowTree())
+     return;
+@@ -1402,6 +1424,10 @@ static void DispatchChildInsertionEvents(Node& child) {
+   Node* c = &child;
+   Document* document = &child.GetDocument();
+ 
++  // csagan5: no extension support in Chrom* for Android? no problem! we add custom code directly here
++  if (c->parentNode())
++      applyInsertCustomization(document, c);
++
+   if (c->parentNode() &&
+       document->HasListenerType(Document::kDOMNodeInsertedListener))
+     c->DispatchScopedEvent(MutationEvent::Create(


### PR DESCRIPTION
I have now added this patch to [Bromite](https://bromite.org/) that removes `onmousedown` from all Google search results hyperlinks; I have not tested if there is any broken functionality in other Google search results pages; normal search results work just fine.

To be honest, I didn't expect a sensible change in page load speed bypassing the Google click-tracking redirect. But it's there and I could notice it from the very first moment...seems like from 0.2 to 0.5 seconds.

Let me know if there are suggestions for improvements; for example the domain check could be moved to the `Document` object, but the patch would be more complex afterwards. Or also the internal listener/events subsystem could be used.