### PR TITLE
Minor improvements to Safe Browsing patch

### DIFF
--- a/0001-fix-building-without-safebrowsing.patch
+++ b/0001-fix-building-without-safebrowsing.patch
@@ -1353,46 +1353,37 @@
      # "Safe Browsing Basic" files used for safe browsing in full mode
 --- a/chrome/browser/net/system_network_context_manager.cc
 +++ b/chrome/browser/net/system_network_context_manager.cc
-@@ -40,22 +40,6 @@ content::mojom::NetworkContextParamsPtr
-   return network_context_params;
- }
- 
--// Called on IOThread to disable QUIC for HttpNetworkSessions not using the
--// network service. Note that re-enabling QUIC dynamically is not supported for
--// simpliciy and requires a browser restart.
+@@ -43,17 +43,11 @@ content::mojom::NetworkContextParamsPtr
+ // Called on IOThread to disable QUIC for HttpNetworkSessions not using the
+ // network service. Note that re-enabling QUIC dynamically is not supported for
+ // simpliciy and requires a browser restart.
 -void DisableQuicOnIOThread(
 -    IOThread* io_thread,
 -    safe_browsing::SafeBrowsingService* safe_browsing_service) {
--  DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
--
--  // Disable QUIC for HttpNetworkSessions using IOThread's NetworkService.
--  io_thread->DisableQuic();
++void DisableQuicOnIOThread(IOThread* io_thread) {
+   DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
+ 
+   // Disable QUIC for HttpNetworkSessions using IOThread's NetworkService.
+   io_thread->DisableQuic();
 -
 -  // Safebrowsing isn't yet using the IOThread's NetworkService, so must be
 -  // handled separately.
 -  safe_browsing_service->DisableQuicOnIOThread();
--}
--
+ }
+ 
  }  // namespace
+@@ -116,11 +110,7 @@ void SystemNetworkContextManager::Disabl
+   if (!io_thread)
+     return;
  
- base::LazyInstance<SystemNetworkContextManager>::Leaky
-@@ -110,17 +94,4 @@ void SystemNetworkContextManager::Disabl
- 
-   if (base::FeatureList::IsEnabled(features::kNetworkService))
-     content::GetNetworkService()->DisableQuic();
--
--  IOThread* io_thread = g_browser_process->io_thread();
--  // Nothing more to do if IOThread has already been shut down.
--  if (!io_thread)
--    return;
--
 -  safe_browsing::SafeBrowsingService* safe_browsing_service =
 -      g_browser_process->safe_browsing_service();
 -
--  content::BrowserThread::PostTask(
--      content::BrowserThread::IO, FROM_HERE,
+   content::BrowserThread::PostTask(
+       content::BrowserThread::IO, FROM_HERE,
 -      base::BindOnce(&DisableQuicOnIOThread, io_thread,
 -                     base::Unretained(safe_browsing_service)));
++      base::BindOnce(&DisableQuicOnIOThread, io_thread));
  }
 --- a/chrome/browser/ui/webui/settings/change_password_handler.cc
 +++ b/chrome/browser/ui/webui/settings/change_password_handler.cc
@@ -1423,12 +1414,133 @@
                               ? IDS_SETTINGS_CHANGE_PASSWORD_TITLE_SOFTER
 --- a/chrome/renderer/chrome_content_renderer_client.cc
 +++ b/chrome/renderer/chrome_content_renderer_client.cc
-@@ -1373,6 +1373,8 @@ bool ChromeContentRendererClient::IsExte
+@@ -58,7 +58,6 @@
+ #include "chrome/renderer/prerender/prerender_dispatcher.h"
+ #include "chrome/renderer/prerender/prerender_helper.h"
+ #include "chrome/renderer/prerender/prerenderer_client.h"
+-#include "chrome/renderer/safe_browsing/phishing_classifier_delegate.h"
+ #include "chrome/renderer/searchbox/search_bouncer.h"
+ #include "chrome/renderer/searchbox/searchbox.h"
+ #include "chrome/renderer/searchbox/searchbox_extension.h"
+@@ -80,9 +79,6 @@
+ #include "components/network_hints/renderer/prescient_networking_dispatcher.h"
+ #include "components/password_manager/content/renderer/credential_manager_client.h"
+ #include "components/pdf/renderer/pepper_pdf_host.h"
+-#include "components/safe_browsing/renderer/renderer_url_loader_throttle.h"
+-#include "components/safe_browsing/renderer/threat_dom_details.h"
+-#include "components/safe_browsing/renderer/websocket_sb_handshake_throttle.h"
+ #include "components/signin/core/common/profile_management_switches.h"
+ #include "components/spellcheck/spellcheck_build_features.h"
+ #include "components/startup_metric_utils/common/startup_metric.mojom.h"
+@@ -442,9 +438,6 @@ void ChromeContentRendererClient::Render
+     thread->AddObserver(spellcheck_.get());
+   }
+ #endif
+-#if defined(FULL_SAFE_BROWSING)
+-  phishing_classifier_.reset(safe_browsing::PhishingClassifierFilter::Create());
+-#endif
+   prerender_dispatcher_.reset(new prerender::PrerenderDispatcher());
+   subresource_filter_ruleset_dealer_.reset(
+       new subresource_filter::UnverifiedRulesetDealer());
+@@ -557,10 +550,6 @@ void ChromeContentRendererClient::Render
+   new nacl::NaClHelper(render_frame);
+ #endif
+ 
+-#if defined(FULL_SAFE_BROWSING)
+-  safe_browsing::ThreatDOMDetails::Create(render_frame);
+-#endif
+-
+ #if BUILDFLAG(ENABLE_PRINTING)
+   new printing::PrintRenderFrameHelper(
+       render_frame, base::MakeUnique<ChromePrintRenderFrameHelperDelegate>());
+@@ -1268,16 +1257,6 @@ bool ChromeContentRendererClient::WillSe
+     const blink::WebURL& url,
+     std::vector<std::unique_ptr<content::URLLoaderThrottle>>* throttles,
+     GURL* new_url) {
+-  if (base::FeatureList::IsEnabled(features::kNetworkService)) {
+-    InitSafeBrowsingIfNecessary();
+-    RenderFrame* render_frame = content::RenderFrame::FromWebFrame(frame);
+-    int render_frame_id =
+-        render_frame ? render_frame->GetRoutingID() : MSG_ROUTING_NONE;
+-    throttles->push_back(
+-        base::MakeUnique<safe_browsing::RendererURLLoaderThrottle>(
+-            safe_browsing_.get(), render_frame_id));
+-  }
+-
+ // Check whether the request should be allowed. If not allowed, we reset the
+ // URL to something invalid to prevent the request and cause an error.
+ #if BUILDFLAG(ENABLE_EXTENSIONS)
+@@ -1373,9 +1352,7 @@ bool ChromeContentRendererClient::IsExte
  
  std::unique_ptr<blink::WebSocketHandshakeThrottle>
  ChromeContentRendererClient::CreateWebSocketHandshakeThrottle() {
+-  InitSafeBrowsingIfNecessary();
+-  return base::MakeUnique<safe_browsing::WebSocketSBHandshakeThrottle>(
+-      safe_browsing_.get());
 +  return nullptr;
-+
-   InitSafeBrowsingIfNecessary();
-   return base::MakeUnique<safe_browsing::WebSocketSBHandshakeThrottle>(
-       safe_browsing_.get());
+ }
+ 
+ std::unique_ptr<blink::WebSpeechSynthesizer>
+@@ -1663,10 +1640,3 @@ ChromeContentRendererClient::GetTaskSche
+   return task_scheduler_util::
+       GetRendererTaskSchedulerInitParamsFromCommandLine();
+ }
+-
+-void ChromeContentRendererClient::InitSafeBrowsingIfNecessary() {
+-  if (safe_browsing_)
+-    return;
+-  RenderThread::Get()->GetConnector()->BindInterface(
+-      content::mojom::kBrowserServiceName, &safe_browsing_);
+-}
+--- a/chrome/renderer/chrome_content_renderer_client.h
++++ b/chrome/renderer/chrome_content_renderer_client.h
+@@ -18,7 +18,6 @@
+ #include "base/strings/string16.h"
+ #include "chrome/renderer/media/chrome_key_systems_provider.h"
+ #include "components/rappor/public/interfaces/rappor_recorder.mojom.h"
+-#include "components/safe_browsing/common/safe_browsing.mojom.h"
+ #include "components/spellcheck/spellcheck_build_features.h"
+ #include "content/public/renderer/content_renderer_client.h"
+ #include "extensions/features/features.h"
+@@ -26,6 +25,7 @@
+ #include "media/media_features.h"
+ #include "ppapi/features/features.h"
+ #include "printing/features/features.h"
++#include "third_party/WebKit/public/platform/WebSocketHandshakeThrottle.h"
+ #include "v8/include/v8.h"
+ 
+ #if defined (OS_CHROMEOS)
+@@ -69,10 +69,6 @@ namespace prerender {
+ class PrerenderDispatcher;
+ }
+ 
+-namespace safe_browsing {
+-class PhishingClassifierFilter;
+-}
+-
+ namespace subresource_filter {
+ class UnverifiedRulesetDealer;
+ }
+@@ -238,9 +234,6 @@ class ChromeContentRendererClient : publ
+   static GURL GetNaClContentHandlerURL(const std::string& actual_mime_type,
+                                        const content::WebPluginInfo& plugin);
+ 
+-  // Initialises |safe_browsing_| if it is not already initialised.
+-  void InitSafeBrowsingIfNecessary();
+-
+   void GetNavigationErrorStringsInternal(
+       content::RenderFrame* render_frame,
+       const blink::WebURLRequest& failed_request,
+@@ -272,12 +265,9 @@ class ChromeContentRendererClient : publ
+ 
+   chrome::ChromeKeySystemsProvider key_systems_provider_;
+ 
+-  safe_browsing::mojom::SafeBrowsingPtr safe_browsing_;
+-
+ #if BUILDFLAG(ENABLE_SPELLCHECK)
+   std::unique_ptr<SpellCheck> spellcheck_;
+ #endif
+-  std::unique_ptr<safe_browsing::PhishingClassifierFilter> phishing_classifier_;
+   std::unique_ptr<subresource_filter::UnverifiedRulesetDealer>
+       subresource_filter_ruleset_dealer_;
+   std::unique_ptr<prerender::PrerenderDispatcher> prerender_dispatcher_;


### PR DESCRIPTION
* Allow Quic to be disabled on the IO thread
* Cleanly remove Safe Browsing code in chrome_content_renderer_client to protect against future changes.

This is derived from https://github.com/Eloston/ungoogled-chromium/commit/d7ec1e9dc7aa0e3f99cb8a00333ce8a890926b53 and https://github.com/Eloston/ungoogled-chromium/commit/a443346f92a9f8a13991a45986c1df20e10be30d 