### PR TITLE
Build without ReportingService

### DIFF
--- a/0002-fix-building-without-reporting.patch
+++ b/0002-fix-building-without-reporting.patch
@@ -1,0 +1,112 @@
+# Fix building with enable_reporting=false
+# In profile_impl_io_data.h/cc and reporting_service_proxy.cc the devs forgot to check if reporting was enabled before using a reporting feature
+# In printer_handler.cc, due to some combination of build flags used in the ungoogled-chromium build, MakeUnique was not pulled in
+
+--- a/chrome/browser/ui/webui/print_preview/printer_handler.cc
++++ b/chrome/browser/ui/webui/print_preview/printer_handler.cc
+@@ -8,6 +8,7 @@
+ #include "chrome/browser/ui/webui/print_preview/extension_printer_handler.h"
+ #include "chrome/browser/ui/webui/print_preview/pdf_printer_handler.h"
+ #include "chrome/common/features.h"
++#include "base/memory/ptr_util.h"
+ 
+ #if BUILDFLAG(ENABLE_SERVICE_DISCOVERY)
+ #include "chrome/browser/ui/webui/print_preview/privet_printer_handler.h"
+--- a/content/browser/net/reporting_service_proxy.cc
++++ b/content/browser/net/reporting_service_proxy.cc
+@@ -97,6 +97,7 @@ class ReportingServiceProxyImpl : public
+                    const std::string& group,
+                    const std::string& type,
+                    std::unique_ptr<base::Value> body) {
++#if BUILDFLAG(ENABLE_REPORTING)
+     net::URLRequestContext* request_context =
+         request_context_getter_->GetURLRequestContext();
+     if (!request_context) {
+@@ -112,6 +113,7 @@ class ReportingServiceProxyImpl : public
+     }
+ 
+     reporting_service->QueueReport(url, group, type, std::move(body));
++#endif
+   }
+ 
+   scoped_refptr<net::URLRequestContextGetter> request_context_getter_;
+--- a/chrome/browser/profiles/profile_impl_io_data.h
++++ b/chrome/browser/profiles/profile_impl_io_data.h
+@@ -182,6 +182,7 @@ class ProfileImplIOData : public Profile
+       const StoragePartitionDescriptor& partition_descriptor) const override;
+   chrome_browser_net::Predictor* GetPredictor() override;
+ 
++#if BUILDFLAG(ENABLE_REPORTING)
+   // Returns a net::ReportingService, if reporting should be enabled. Otherwise,
+   // returns nullptr.
+   // TODO(mmenke): Remove once URLRequestContextBuilders are always used to
+@@ -192,6 +193,7 @@ class ProfileImplIOData : public Profile
+   // Returns a net::ReportingPolicy, if reporting should be enabled. Otherwise,
+   // returns nullptr.
+   static std::unique_ptr<net::ReportingPolicy> MaybeCreateReportingPolicy();
++#endif
+ 
+   // Lazy initialization params.
+   mutable std::unique_ptr<LazyParams> lazy_params_;
+--- a/chrome/browser/profiles/profile_impl_io_data.cc
++++ b/chrome/browser/profiles/profile_impl_io_data.cc
+@@ -472,7 +472,9 @@ void ProfileImplIOData::InitializeIntern
+       builder, std::move(request_interceptors),
+       std::move(profile_params->protocol_handler_interceptor));
+ 
++#if BUILDFLAG(ENABLE_REPORTING)
+   builder->set_reporting_policy(MaybeCreateReportingPolicy());
++#endif
+ }
+ 
+ void ProfileImplIOData::OnMainRequestContextCreated(
+@@ -608,7 +610,9 @@ net::URLRequestContext* ProfileImplIODat
+           context->host_resolver()));
+   context->SetJobFactory(std::move(top_job_factory));
+ 
++#if BUILDFLAG(ENABLE_REPORTING)
+   context->SetReportingService(MaybeCreateReportingService(context));
++#endif
+ 
+   return context;
+ }
+@@ -698,6 +702,7 @@ chrome_browser_net::Predictor* ProfileIm
+   return predictor_.get();
+ }
+ 
++#if BUILDFLAG(ENABLE_REPORTING)
+ std::unique_ptr<net::ReportingService>
+ ProfileImplIOData::MaybeCreateReportingService(
+     net::URLRequestContext* url_request_context) const {
+@@ -716,3 +721,4 @@ ProfileImplIOData::MaybeCreateReportingP
+ 
+   return base::MakeUnique<net::ReportingPolicy>();
+ }
++#endif
+--- a/chrome/browser/profiles/profile_io_data.cc
++++ b/chrome/browser/profiles/profile_io_data.cc
+@@ -638,7 +638,9 @@
+ void ProfileIOData::AppRequestContext::SetReportingService(
+     std::unique_ptr<net::ReportingService> reporting_service) {
+   reporting_service_ = std::move(reporting_service);
++#if BUILDFLAG(ENABLE_REPORTING)
+   set_reporting_service(reporting_service_.get());
++#endif
+ }
+ 
+ ProfileIOData::AppRequestContext::~AppRequestContext() {
+--- a/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.cc
++++ b/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.cc
+@@ -252,10 +252,12 @@
+     const base::Callback<bool(const GURL&)>& origin_filter) {
+   DCHECK_CURRENTLY_ON(BrowserThread::IO);
+ 
++#if BUILDFLAG(ENABLE_REPORTING)
+   net::ReportingService* service =
+       context->GetURLRequestContext()->reporting_service();
+   if (service)
+     service->RemoveBrowsingData(data_type_mask, origin_filter);
++#endif
+ }
+ 
+ #if defined(OS_ANDROID)

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -45,6 +45,7 @@ source=(https://commondatastorage.googleapis.com/chromium-browser-official/chrom
         https://raw.githubusercontent.com/gcarq/inox-patchset/$pkgver/chromium-vaapi-r16.patch
         # Inox patchset
         https://raw.githubusercontent.com/gcarq/inox-patchset/$pkgver/0001-fix-building-without-safebrowsing.patch
+        https://raw.githubusercontent.com/gcarq/inox-patchset/$pkgver/0002-fix-building-without-reporting.patch
         https://raw.githubusercontent.com/gcarq/inox-patchset/$pkgver/0003-disable-autofill-download-manager.patch
         https://raw.githubusercontent.com/gcarq/inox-patchset/$pkgver/0004-disable-google-url-tracker.patch
         https://raw.githubusercontent.com/gcarq/inox-patchset/$pkgver/0005-disable-default-extensions.patch
@@ -65,8 +66,6 @@ source=(https://commondatastorage.googleapis.com/chromium-browser-official/chrom
         https://raw.githubusercontent.com/gcarq/inox-patchset/$pkgver/0020-launcher-branding.patch
         https://raw.githubusercontent.com/gcarq/inox-patchset/$pkgver/0021-disable-rlz.patch
         https://raw.githubusercontent.com/gcarq/inox-patchset/$pkgver/9000-disable-metrics.patch)
-
-
 sha256sums=('342ea80a925d85f5155b2b423a0d3cbcf2ee5729bf107c601d7d902315d03127'
             '4dc3428f2c927955d9ae117f2fb24d098cc6dd67adb760ac9c82b522ec8b0587'
             'a86a8ec67aed5a94557257b9826c5b8fe37005e8376e75986fee77acd066539a'
@@ -90,6 +89,7 @@ sha256sums=('342ea80a925d85f5155b2b423a0d3cbcf2ee5729bf107c601d7d902315d03127'
             '0a9186ab591773f8fb6cbc908f9bbf4bc1508f1095b6c1cd7479aac945045373'
             'b82047df666e6bbf66e0c0911d20c5001bd1100fd08adafa92cac5f02a887a01'
             'd1e112adb135a823907aae33b189cb775d48e6afa785a26a452fc833824cd2e8'
+            '300a7f3f0aba2037d159e5815f5cb3f2699c0ac26cbbb61209bbf01ac1eb2efb'
             '605cca8be9828a29cc96d473847eef9452d572fe6a56dacd96426a202310ba58'
             'fb91a7e30e2615e4eb0626b0fdcf97b92d4a727a52023730f408b02fee436c8d'
             '6ba0ad7d91b2f3bbf03fc4a3236a04310a0c57505e1688c7e11ace9dcea1dded'
@@ -193,6 +193,7 @@ prepare() {
   msg2 'Applying Inox patchset'
   # Apply patches to fix building
   patch -Np1 -i ../0001-fix-building-without-safebrowsing.patch
+  patch -Np1 -i ../0002-fix-building-without-reporting.patch
 
   # Apply Inox patches
   patch -Np1 -i ../0003-disable-autofill-download-manager.patch
@@ -268,8 +269,6 @@ build() {
   export AR=llvm-ar
   export NM=llvm-nm
 
-  # TODO: enable_mdns=false (linker error)
-  # TODO: enable_reporting=false (compiler error)
   local _flags=(
     'custom_toolchain="//build/toolchain/linux/unbundle:default"'
     'host_toolchain="//build/toolchain/linux/unbundle:default"'
@@ -302,6 +301,7 @@ build() {
     'enable_nacl_nonsfi=false'
     'enable_remoting=false'
     'enable_google_now=false'
+    'enable_reporting=false'
     'safe_browsing_mode=0'
   )
 


### PR DESCRIPTION
Allow building with the setting enable_reporting=false to exclude the ReportingService.

The patch originates from LeFroid's PR for ungoogled-chromium at Eloston/ungoogled-chromium#329.